### PR TITLE
Improve query plan cost estimation.

### DIFF
--- a/lib/AtteanX/Model/SPARQLCache.pm
+++ b/lib/AtteanX/Model/SPARQLCache.pm
@@ -21,26 +21,31 @@ sub plans_for_algebra {
 	return;
 }
 
-sub cost_for_plan { # TODO: Do this for real
+sub cost_for_plan {
  	my $self	= shift;
  	my $plan	= shift;
+ 	my $planner	= shift;
 	my $joinfactor = ($plan->isa('Attean::Plan::HashJoin')) ? 9 : 10; # Consistently prefer HashJoins unless treated specially
-	if ($plan->does('Attean::API::Plan::Join')) {
-		if (${$plan->children}[0]->isa('Attean::Plan::Quad') && ${$plan->children}[1]->isa('Attean::Plan::Quad')) {
-			return $joinfactor * 1000
-		} elsif (${$plan->children}[0]->isa('Attean::Plan::Table') && ${$plan->children}[1]->isa('AtteanX::Store::SPARQL::Plan::BGP')) {
-			if (defined(my $cost = ${$plan->children}[1]->cost)) {
-				return int($cost * $joinfactor / 20);
-			} else {
-				return;
-			}
-		} elsif (${$plan->children}[1]->isa('Attean::Plan::Table') && ${$plan->children}[0]->isa('AtteanX::Store::SPARQL::Plan::BGP')) {
-			if (defined(my $cost = ${$plan->children}[0]->cost)) {
-				return int($cost * $joinfactor / 15);
-			} else {
-				return;
-			}
+	if ($plan->isa('AtteanX::Store::SPARQL::Plan::BGP')) {
+		# BGPs should have a cost proportional to the number of triple patterns,
+		# but be much more costly if they contain a cartesian product.
+		if ($plan->children_are_variable_connected) {
+			return 10 * scalar(@{ $plan->children });
+		} else {
+			return 100 * scalar(@{ $plan->children });
 		}
+# 	} elsif ($plan->does('Attean::API::Plan::Join')) {
+# 		if (${$plan->children}[0]->isa('Attean::Plan::Table') && ${$plan->children}[1]->isa('AtteanX::Store::SPARQL::Plan::BGP')) {
+# 			my $bgpcost	= $planner->cost_for_plan(${$plan->children}[1], $self);
+# 			my $cost	= int($bgpcost * $joinfactor / 20);
+# # 			say "1 Join costs: $bgpcost => $cost\n";
+# 			return $cost;
+# 		} elsif (${$plan->children}[1]->isa('Attean::Plan::Table') && ${$plan->children}[0]->isa('AtteanX::Store::SPARQL::Plan::BGP')) {
+# 			my $bgpcost	= $planner->cost_for_plan(${$plan->children}[0], $self);
+# 			my $cost	= int($bgpcost * $joinfactor / 15);
+# # 			say "2 Join costs: $bgpcost => $cost\n";
+# 			return $cost;
+# 		}
 	} elsif ($plan->isa('Attean::Plan::Table')) {
  		return 2;
 	} elsif ($plan->isa('Attean::Plan::Quad')) {


### PR DESCRIPTION
This relies on cost() and has_cost() being removed from AtteanX::Store::SPARQL::Plan::BGP. It works for me by just commenting them out, but then it breaks tests in p5-atteanx-store-sparql that rely on those methods. I'd recommend:
- Moving the cost() method into AtteanX::Model::SPARQL
- Updating the p5-atteanx-store-sparql tests to create a AtteanX::Model::SPARQL model, and test against it's cost_for_plan method

After that's done, and assuming I've understood all the tests, this PR should make everything in t/simple-sparql-planner.t pass.

t/analysis.t still fails for me. I haven't looked into that code yet. Can you let me know if I should keep digging into that, or if this PR resolves some of the issues?

Thanks!
